### PR TITLE
EXEC-434 fix import results when case was deleted

### DIFF
--- a/src/service/qase.py
+++ b/src/service/qase.py
@@ -219,12 +219,13 @@ class QaseService:
                     else:
                         start_time = tr_run['created_on'] - elapsed
 
-                    data = {
-                        "case_id": cases_map[result['test_id']],
-                        "status": status_map.get(str(result["status_id"]), "skipped"),
-                        "time_ms": elapsed*1000, # converting to miliseconds
-                        "comment": str(result['comment'])
-                    }
+                    if result['test_id'] in cases_map:
+                        data = {
+                            "case_id": cases_map[result['test_id']],
+                            "status": status_map.get(str(result["status_id"]), "skipped"),
+                            "time_ms": elapsed*1000, # converting to miliseconds
+                            "comment": str(result['comment'])
+                        }
 
                     if (start_time):
                         data['start_time'] = start_time


### PR DESCRIPTION
Resolved issue when `result` has link to `test_id`, but that `test_id` doesn't exist in the `cases_map`

![image (3)](https://github.com/n3r/qase-testrail-migration/assets/6221721/99fc4822-f186-4f00-9675-4de135c6c018)